### PR TITLE
1.0.0-alpha2

### DIFF
--- a/tests/Functional/SitewideSearchTest.php
+++ b/tests/Functional/SitewideSearchTest.php
@@ -2,6 +2,9 @@
 
 namespace Drupal\Tests\localgov_search_solr\Functional;
 
+use Drupal\search_api\Entity\Index;
+use Drupal\search_api\Entity\Server;
+use Drupal\search_api_solr\Utility\SolrCommitTrait;
 use Drupal\Tests\localgov_search\Functional\SitewideSearchBase;
 
 /**
@@ -10,6 +13,8 @@ use Drupal\Tests\localgov_search\Functional\SitewideSearchBase;
  * @group localgov_search
  */
 class SitewideSearchTest extends SitewideSearchBase {
+
+  use SolrCommitTrait;
 
   /**
    * Modules to enable.
@@ -20,5 +25,38 @@ class SitewideSearchTest extends SitewideSearchBase {
     'localgov_search',
     'localgov_search_solr',
   ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    $server = Server::load('localgov_sitewide_solr');
+    if (!$server->isAvailable()) {
+      $this->markTestSkipped('No solr server available for test to run');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    $index = Index::load('localgov_sitewide_search');
+    $index->clear();
+    $this->ensureCommit($index);
+
+    parent::tearDown();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function indexItems() {
+    // Index content.
+    $index = Index::load('localgov_sitewide_search');
+    $index->indexItems();
+    $this->ensureCommit($index);
+  }
 
 }


### PR DESCRIPTION
* Skip tests if no solr backend.

Also adds clean-up after test is run, because drupal tests do this for the db not solr.

* Add method to be used in https://github.com/localgovdrupal/localgov_search/pull/49/commits/18380fe27e6ae113cbaf460131f2e37ae3cd4aa2

This, without a cache clear, ensures the items are indexed for the test.